### PR TITLE
fix li margin on cheerpj.com navbar

### DIFF
--- a/packages/global-navbar/src/items/Item.svelte
+++ b/packages/global-navbar/src/items/Item.svelte
@@ -5,5 +5,6 @@
 <style>
 	li {
 		height: 1.5rem;
+		margin: 0; /* required to override style on cheerpj.com */
 	}
 </style>

--- a/packages/global-navbar/src/popover/BigIcon.svelte
+++ b/packages/global-navbar/src/popover/BigIcon.svelte
@@ -11,3 +11,9 @@
 		<span>{description}</span>
 	</a>
 </li>
+
+<style>
+	li {
+		margin: 0; /* required to override style on cheerpj.com */
+	}
+</style>


### PR DESCRIPTION
The WordPress theme on cheerpj.com adds a bottom margin to all `li` elements by default, which we don't want

![image](https://github.com/user-attachments/assets/418fc583-1ea9-4f62-bd5a-39eeb9956338)
