### PR TITLE
Added more context to the new CJ native method docs.

### DIFF
--- a/sites/cheerpj/src/content/docs/13-tutorials/05-interoperability-tutorial.mdx
+++ b/sites/cheerpj/src/content/docs/13-tutorials/05-interoperability-tutorial.mdx
@@ -9,6 +9,8 @@ With CheerpJ, a Java application can interact with JavaScript in a browser envir
 
 In this tutorial, we’ll teach you how to create a two-way communication channel between Java and JavaScript using CheerpJ. This setup will allow a Java class to access JavaScript functions and vice versa, enabling data exchange between the two environments.
 
+We will use a long-running Java thread to enable callbacks into our Java application at any time. It is also possible to call back into Java using native methods, which we explain further in our [`native methods guide`].
+
 ## Prerequisites
 
 - [Download the template project](/docs/cheerpj3/tutorials/CheerpJInteroperabilityTutorial.zip) and unzip it.
@@ -202,3 +204,4 @@ npx http-server -p 8080
 [`http-server`]: https://www.npmjs.com/package/http-server
 [`native`]: /docs/guides/implementing-native-methods
 [`native method`]: /docs/guides/implementing-native-methods
+[`native methods guide`]: /docs/guides/implementing-native-methods#calling-back-into-java-from-javascript


### PR DESCRIPTION
I added a bit more context to the new tutorial and guide. I renamed the native java function from `alert()` to `nativeAlert()` to avoid confusion with JavaScript method of the same name. I also added a part to the guide that explains how to call back to Java using the `lib` parameter and referenced that in the tutorial.