### PR TITLE
Latestblog

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Labs
+
 Labs is the monorepo codebase for Leaning Technologies developer sites. It contains technical writing (documentation and blog posts) for Cheerp, CheerpJ, CheerpX and other projects.
 
 Visit our sites:
+
 - [Labs](https://labs.leaningtech.com/)
 - [Cheerp.io](https://cheerp.io/)
 - [CheerpX.io](https://cheerpx.io/)
@@ -10,25 +12,31 @@ Visit our sites:
 # Running locally
 
 ## Setup
+
 Make sure you have [Node.js](https://nodejs.org/en/download/package-manager) and [pnpm](https://pnpm.io/installation) installed.
 
 ## Clone this repository
+
 ```shell
 git clone https://github.com/leaningtech/labs.git
 ```
 
 ## Install dependencies
+
 ```shell
 cd labs
 pnpm install
 ```
 
 ## Run a site
+
 The sites under this repository must be run individually. Pick a site you want to run, for example [Cheerp.io](Cheerp.io):
+
 ```shell
 cd /sites/cheerp
 pnpm start
 ```
 
 # Contributing
+
 For more information about contributing, please [visit this page](https://labs.leaningtech.com/docs/contributing)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pnpm install
 
 ## Run a site
 
-The sites under this repository must be run individually. Pick a site you want to run, for example [Cheerp.io](Cheerp.io):
+The sites under this repository must be run individually. Pick a site you want to run, for example [Cheerp.io](https://cheerp.io/):
 
 ```shell
 cd /sites/cheerp

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Labs
+Labs is the monorepo codebase for Leaning Technologies developer sites. It contains technical writing (documentation and blog posts) for Cheerp, CheerpJ, CheerpX and other projects.
+
+Visit our sites:
+- [Labs](https://labs.leaningtech.com/)
+- [Cheerp.io](https://cheerp.io/)
+- [CheerpX.io](https://cheerpx.io/)
+- [CheerpJ.com](https://cheerpj.com/)
+
+# Running locally
+
+## Setup
+Make sure you have [Node.js](https://nodejs.org/en/download/package-manager) and [pnpm](https://pnpm.io/installation) installed.
+
+## Clone this repository
+```shell
+git clone https://github.com/leaningtech/labs.git
+```
+
+## Install dependencies
+```shell
+cd labs
+pnpm install
+```
+
+## Run a site
+The sites under this repository must be run individually. Pick a site you want to run, for example [Cheerp.io](Cheerp.io):
+```shell
+cd /sites/cheerp
+pnpm start
+```
+
+# Contributing
+For more information about contributing, please [visit this page](https://labs.leaningtech.com/docs/contributing)

--- a/packages/astro-theme/components/BlogPostCard.astro
+++ b/packages/astro-theme/components/BlogPostCard.astro
@@ -21,8 +21,7 @@ const post =
 const authors = await resolveAuthors(post.data.authors);
 
 //choose hover link color based on product
-const productName = typeof product === "undefined"? "Labs": product.name;
-
+const productName = typeof product === "undefined" ? "Labs" : product.name;
 ---
 
 <a

--- a/packages/astro-theme/components/BlogPostCard.astro
+++ b/packages/astro-theme/components/BlogPostCard.astro
@@ -3,6 +3,9 @@ import { getEntry, type CollectionEntry } from "astro:content";
 import FormattedDate from "./FormattedDate.astro";
 import { resolveAuthors } from "../lib/blog";
 import { Image } from "astro:assets";
+import { productFromUrl } from "../lib/products";
+
+const product = productFromUrl(Astro.url);
 
 interface Props {
 	post: CollectionEntry<"blog"> | CollectionEntry<"blog">["slug"];
@@ -16,6 +19,10 @@ const post =
 		? await getEntry("blog", postOrSlug)
 		: postOrSlug;
 const authors = await resolveAuthors(post.data.authors);
+
+//choose hover link color based on product
+const productName = typeof product === "undefined"? "Labs": product.name;
+
 ---
 
 <a
@@ -35,7 +42,10 @@ const authors = await resolveAuthors(post.data.authors);
 	}
 	<h3
 		class:list={{
-			"font-bold text-balance text-white group-hover:text-primary-400 grow": true,
+			"font-bold text-balance text-white grow": true,
+			"group-hover:text-cheerp grow": productName === "Cheerp",
+			"group-hover:text-[#6386a5] grow": productName === "CheerpX",
+			"group-hover:text-primary-400 grow": productName === "Labs",
 			"text-2xl leading-7": size === "wide",
 			"text-xl leading-6": size === "narrow",
 		}}

--- a/packages/astro-theme/components/BlogPostCardSet.astro
+++ b/packages/astro-theme/components/BlogPostCardSet.astro
@@ -15,6 +15,7 @@ interface Props {
 
 const { tags, exclude } = Astro.props;
 const product = productFromUrl(Astro.url);
+const productName = typeof product === "undefined"? "Labs": product.name;
 
 
 function sortCalc(post: CollectionEntry<"blog">): number {
@@ -30,10 +31,13 @@ function sortCalc(post: CollectionEntry<"blog">): number {
 
 const posts = (
 	await getCollection("blog", (post) => {
-		if (post.data.draft || exclude?.includes(post.id) || !post.data?.tags?.includes(product.name)) {
+		if (post.data.draft || exclude?.includes(post.id) || !(post.data?.tags?.includes(productName) || productName === "Labs")) {
 			return false;
+			
+		} else {
+			return true;
 		}
-		return true;
+		
 	})
 )
 	.sort((a, b) => sortCalc(b) - sortCalc(a))

--- a/packages/astro-theme/components/BlogPostCardSet.astro
+++ b/packages/astro-theme/components/BlogPostCardSet.astro
@@ -1,6 +1,9 @@
 ---
 import { getCollection, type CollectionEntry } from "astro:content";
 import BlogPostCard from "./BlogPostCard.astro";
+import { productFromUrl } from "../lib/products";
+
+
 
 interface Props {
 	// Only show posts if they have at least one of these tags
@@ -11,6 +14,8 @@ interface Props {
 }
 
 const { tags, exclude } = Astro.props;
+const product = productFromUrl(Astro.url);
+
 
 function sortCalc(post: CollectionEntry<"blog">): number {
 	let relevancy =
@@ -25,7 +30,7 @@ function sortCalc(post: CollectionEntry<"blog">): number {
 
 const posts = (
 	await getCollection("blog", (post) => {
-		if (post.data.draft || exclude?.includes(post.id)) {
+		if (post.data.draft || exclude?.includes(post.id) || !post.data?.tags?.includes(product.name)) {
 			return false;
 		}
 		return true;

--- a/packages/astro-theme/components/BlogPostCardSet.astro
+++ b/packages/astro-theme/components/BlogPostCardSet.astro
@@ -3,8 +3,6 @@ import { getCollection, type CollectionEntry } from "astro:content";
 import BlogPostCard from "./BlogPostCard.astro";
 import { productFromUrl } from "../lib/products";
 
-
-
 interface Props {
 	// Only show posts if they have at least one of these tags
 	tags?: string[] | undefined;
@@ -15,8 +13,7 @@ interface Props {
 
 const { tags, exclude } = Astro.props;
 const product = productFromUrl(Astro.url);
-const productName = typeof product === "undefined"? "Labs": product.name;
-
+const productName = typeof product === "undefined" ? "Labs" : product.name;
 
 function sortCalc(post: CollectionEntry<"blog">): number {
 	let relevancy =
@@ -31,13 +28,15 @@ function sortCalc(post: CollectionEntry<"blog">): number {
 
 const posts = (
 	await getCollection("blog", (post) => {
-		if (post.data.draft || exclude?.includes(post.id) || !(post.data?.tags?.includes(productName) || productName === "Labs")) {
+		if (
+			post.data.draft ||
+			exclude?.includes(post.id) ||
+			!(post.data?.tags?.includes(productName) || productName === "Labs")
+		) {
 			return false;
-			
 		} else {
 			return true;
 		}
-		
 	})
 )
 	.sort((a, b) => sortCalc(b) - sortCalc(a))

--- a/sites/cheerp/src/pages/index.astro
+++ b/sites/cheerp/src/pages/index.astro
@@ -183,7 +183,7 @@ import BlogPostCardSet from "@leaningtech/astro-theme/components/BlogPostCardSet
 		</div>
 	</section>
 	<section class="bg-stone-900 py-16">
-		<div class="px-4 sm:p-8 md:px-16 lg:px-32 xl:px-56 2xl:px-60">
+		<div class="w-full max-w-screen-2xl mx-auto px-16">
 			<div class="mb-8">
 				<p class="text-lg text-stone-400">Cheerp blog</p>
 				<h2 class="text-4xl font-bold text-white">Latest news</h2>

--- a/sites/cheerp/src/pages/index.astro
+++ b/sites/cheerp/src/pages/index.astro
@@ -188,7 +188,7 @@ import BlogPostCardSet from "@leaningtech/astro-theme/components/BlogPostCardSet
 				<p class="text-lg text-stone-400">Cheerp blog</p>
 				<h2 class="text-4xl font-bold text-white">Latest news</h2>
 			</div>
-			<BlogPostCardSet/>
+			<BlogPostCardSet />
 			<div class="mt-8">
 				<LinkButton
 					type="secondary-cheerp"
@@ -198,7 +198,6 @@ import BlogPostCardSet from "@leaningtech/astro-theme/components/BlogPostCardSet
 				/>
 			</div>
 		</div>
-		
 	</section>
 	<section
 		class="bg-gradient-to-b from-stone-900 to-[#474484] pb-48 text-center pb-28 md:px-8 md:pt-16 lg:px-32 lg:pt-32 xl:pt-42 xl:px-28 2xl:px-60 2xl:pt-60"

--- a/sites/cheerp/src/pages/index.astro
+++ b/sites/cheerp/src/pages/index.astro
@@ -9,6 +9,7 @@ import IconLayers from "../assets/layers.png";
 import DrawingSourcerer from "../assets/sourcerer.png";
 import { Image } from "astro:assets";
 import { DISCORD_URL } from "@leaningtech/astro-theme/consts";
+import BlogPostCardSet from "@leaningtech/astro-theme/components/BlogPostCardSet.astro";
 ---
 
 <ProductHome style="w-full pt-8 bg-gradient-to-b from-stone-900 to-cheerp">
@@ -179,6 +180,21 @@ import { DISCORD_URL } from "@leaningtech/astro-theme/consts";
 					</a>
 				</div>
 			</div>
+		</div>
+	</section>
+	<section class="w-full max-w-screen-2xl mx-auto px-6 py-10">
+		<div class="mb-8">
+			<p class="text-lg text-stone-400">CheerpX blog</p>
+			<h2 class="text-4xl font-bold text-white">Latest news</h2>
+		</div>
+		<BlogPostCardSet/>
+		<div class="mt-8">
+			<LinkButton
+				type="cheerpx-secondary"
+				href="/blog"
+				label="View all blog posts"
+				iconRight="mi:arrow-right"
+			/>
 		</div>
 	</section>
 	<section

--- a/sites/cheerp/src/pages/index.astro
+++ b/sites/cheerp/src/pages/index.astro
@@ -182,20 +182,23 @@ import BlogPostCardSet from "@leaningtech/astro-theme/components/BlogPostCardSet
 			</div>
 		</div>
 	</section>
-	<section class="w-full max-w-screen-2xl mx-auto px-6 py-10">
-		<div class="mb-8">
-			<p class="text-lg text-stone-400">CheerpX blog</p>
-			<h2 class="text-4xl font-bold text-white">Latest news</h2>
+	<section class="bg-stone-900 py-16">
+		<div class="px-4 sm:p-8 md:px-16 lg:px-32 xl:px-56 2xl:px-60">
+			<div class="mb-8">
+				<p class="text-lg text-stone-400">Cheerp blog</p>
+				<h2 class="text-4xl font-bold text-white">Latest news</h2>
+			</div>
+			<BlogPostCardSet/>
+			<div class="mt-8">
+				<LinkButton
+					type="secondary-cheerp"
+					href="/blog"
+					label="View all blog posts"
+					iconRight="mi:arrow-right"
+				/>
+			</div>
 		</div>
-		<BlogPostCardSet/>
-		<div class="mt-8">
-			<LinkButton
-				type="cheerpx-secondary"
-				href="/blog"
-				label="View all blog posts"
-				iconRight="mi:arrow-right"
-			/>
-		</div>
+		
 	</section>
 	<section
 		class="bg-gradient-to-b from-stone-900 to-[#474484] pb-48 text-center pb-28 md:px-8 md:pt-16 lg:px-32 lg:pt-32 xl:pt-42 xl:px-28 2xl:px-60 2xl:pt-60"

--- a/sites/cheerpx/src/pages/index.astro
+++ b/sites/cheerpx/src/pages/index.astro
@@ -214,20 +214,23 @@ import BlogPostCardSet from "@leaningtech/astro-theme/components/BlogPostCardSet
 			</div>
 		</div>
 	</section>
-	<section class="w-full max-w-screen-2xl mx-auto px-6 py-10">
-		<div class="mb-8">
-			<p class="text-lg text-stone-400">CheerpX blog</p>
-			<h2 class="text-4xl font-bold text-white">Latest news</h2>
+	<section class="bg-black py-16">
+		<div class="px-4 sm:p-8 md:px-16 lg:px-32 xl:px-56 2xl:px-60">
+			<div class="mb-8">
+				<p class="text-lg text-stone-400">CheerpX blog</p>
+				<h2 class="text-4xl font-bold text-white">Latest news</h2>
+			</div>
+			<BlogPostCardSet/>
+			<div class="mt-8">
+				<LinkButton
+					type="secondary-cheerpx"
+					href="/blog"
+					label="View all blog posts"
+					iconRight="mi:arrow-right"
+				/>
+			</div>
 		</div>
-		<BlogPostCardSet tags = "CheerpX"/>
-		<div class="mt-8">
-			<LinkButton
-				type="cheerpx-secondary"
-				href="/blog"
-				label="View all blog posts"
-				iconRight="mi:arrow-right"
-			/>
-		</div>
+		
 	</section>
 	<section
 		class="bg-gradient-to-b from-black to-[#00254d] pb-48 text-center pb-28 md:px-8 md:pt-16 lg:px-32 pt-12 lg:pt-32 xl:pt-42 xl:px-28 2xl:px-60 2xl:pt-60"

--- a/sites/cheerpx/src/pages/index.astro
+++ b/sites/cheerpx/src/pages/index.astro
@@ -215,7 +215,7 @@ import BlogPostCardSet from "@leaningtech/astro-theme/components/BlogPostCardSet
 		</div>
 	</section>
 	<section class="bg-black py-16">
-		<div class="px-4 sm:p-8 md:px-16 lg:px-32 xl:px-56 2xl:px-60">
+		<div class="w-full max-w-screen-2xl mx-auto px-16">
 			<div class="mb-8">
 				<p class="text-lg text-stone-400">CheerpX blog</p>
 				<h2 class="text-4xl font-bold text-white">Latest news</h2>

--- a/sites/cheerpx/src/pages/index.astro
+++ b/sites/cheerpx/src/pages/index.astro
@@ -220,7 +220,7 @@ import BlogPostCardSet from "@leaningtech/astro-theme/components/BlogPostCardSet
 				<p class="text-lg text-stone-400">CheerpX blog</p>
 				<h2 class="text-4xl font-bold text-white">Latest news</h2>
 			</div>
-			<BlogPostCardSet/>
+			<BlogPostCardSet />
 			<div class="mt-8">
 				<LinkButton
 					type="secondary-cheerpx"
@@ -230,7 +230,6 @@ import BlogPostCardSet from "@leaningtech/astro-theme/components/BlogPostCardSet
 				/>
 			</div>
 		</div>
-		
 	</section>
 	<section
 		class="bg-gradient-to-b from-black to-[#00254d] pb-48 text-center pb-28 md:px-8 md:pt-16 lg:px-32 pt-12 lg:pt-32 xl:pt-42 xl:px-28 2xl:px-60 2xl:pt-60"
@@ -303,5 +302,4 @@ import BlogPostCardSet from "@leaningtech/astro-theme/components/BlogPostCardSet
 			</div>
 		</div>
 	</section>
-	
 </ProductHome>

--- a/sites/cheerpx/src/pages/index.astro
+++ b/sites/cheerpx/src/pages/index.astro
@@ -9,6 +9,7 @@ import Screenshot from "../assets/screenshots.png";
 import { Image } from "astro:assets";
 import { DISCORD_URL } from "@leaningtech/astro-theme/consts";
 import MonitorDoodle from "../assets/hero_illustration.png";
+import BlogPostCardSet from "@leaningtech/astro-theme/components/BlogPostCardSet.astro";
 ---
 
 <ProductHome style="w-full pt-8 bg-gradient-to-b from-stone-900 to-[#00254d]">
@@ -213,6 +214,21 @@ import MonitorDoodle from "../assets/hero_illustration.png";
 			</div>
 		</div>
 	</section>
+	<section class="w-full max-w-screen-2xl mx-auto px-6 py-10">
+		<div class="mb-8">
+			<p class="text-lg text-stone-400">CheerpX blog</p>
+			<h2 class="text-4xl font-bold text-white">Latest news</h2>
+		</div>
+		<BlogPostCardSet tags = "CheerpX"/>
+		<div class="mt-8">
+			<LinkButton
+				type="cheerpx-secondary"
+				href="/blog"
+				label="View all blog posts"
+				iconRight="mi:arrow-right"
+			/>
+		</div>
+	</section>
 	<section
 		class="bg-gradient-to-b from-black to-[#00254d] pb-48 text-center pb-28 md:px-8 md:pt-16 lg:px-32 pt-12 lg:pt-32 xl:pt-42 xl:px-28 2xl:px-60 2xl:pt-60"
 	>
@@ -284,4 +300,5 @@ import MonitorDoodle from "../assets/hero_illustration.png";
 			</div>
 		</div>
 	</section>
+	
 </ProductHome>


### PR DESCRIPTION
I have made the following changes:
- Added the "latest blog" section (BlogPostCardset component) to cheerp.io and cheerpx.io Each section should only show the latest blogpost of the product. For example, for CheerpX.io only CheerpX related posts and so on. Labs should show the latest posts of all the products on the latest news section.
- The BlogPostSet component colors on the URL post title should match the color of the website (primary-400 for labs, cheerp green for cheerp and blue-ish for cheerpX). 

Please when reviewing this PR make sure to test and check works as intended. 