### PR TITLE
Added more contest to the GPO AppletRunner guide

### DIFF
--- a/sites/labs/src/content/docs/cheerpj-applet-runner/04-guides/private-hosting-chrome.mdx
+++ b/sites/labs/src/content/docs/cheerpj-applet-runner/04-guides/private-hosting-chrome.mdx
@@ -29,13 +29,13 @@ The extension ID is a unique identifier used by the Chrome WebStore. You can ret
 https://chromewebstore.google.com/detail/cheerpj-applet-runner/bbmolahhldcbngedljfadjlognfaaein
 ```
 
-The extension ID is:
+The extension ID of the official Chrome WebStore version is:
 
 ```
 bbmolahhldcbngedljfadjlognfaaein
 ```
 
-Or if you use a custom extension build, navigate to `chrome://extensions/` in Chrome, and retrieve it from there.
+Or if you use a custom extension build, navigate to `chrome://extensions/` in Chrome, and retrieve it from there. You will first need to enable **Developer mode** at the top right of the page in order to view the ID.
 
 <div class="flex justify-center">
 	<img
@@ -44,6 +44,9 @@ Or if you use a custom extension build, navigate to `chrome://extensions/` in Ch
 		alt="Chrome manage extension page"
 	/>
 </div>
+
+> [!warning] Example Extension ID
+> Custom Extension builds all have unique IDs. The version you will be installing will have a different ID than seen on the screenshot.
 
 You can find more information on how to pack and manually install the Applet Runner extension in our [documentation](/docs/cheerpj-applet-runner/getting-started/packing-extension-chrome).
 

--- a/sites/labs/src/content/docs/cheerpj-applet-runner/04-guides/private-hosting-edge.mdx
+++ b/sites/labs/src/content/docs/cheerpj-applet-runner/04-guides/private-hosting-edge.mdx
@@ -29,13 +29,13 @@ The extension ID is a unique identifier you can easily retrieve from the [extens
 https://microsoftedge.microsoft.com/addons/detail/cheerpj-applet-runner/ebfcpaoldmijengghefpohddmfpndmic
 ```
 
-The extension ID is:
+The extension ID of the official Edge Add-ons store version is:
 
 ```
 ebfcpaoldmijengghefpohddmfpndmic
 ```
 
-Or if you use a custom extension build, navigate to `edge://extensions/` in Edge, and retrieve it from there.
+Or if you use a custom extension build, navigate to `edge://extensions/` in Edge, and retrieve it from there. You will first need to enable **Developer mode** in the left menu in order to view the ID.
 
 <div class="flex justify-center">
 	<img
@@ -44,6 +44,9 @@ Or if you use a custom extension build, navigate to `edge://extensions/` in Edge
 		alt="Edge manage extension page"
 	/>
 </div>
+
+> [!warning] Example Extension ID
+> Custom Extension builds all have unique IDs. The version you will be installing will have a different ID than seen on the screenshot.
 
 You can find more information on how to pack and manually install the Applet Runner extension in our [documentation](/docs/cheerpj-applet-runner/getting-started/packing-extension-edge).
 


### PR DESCRIPTION
We got some reports of clients being confused by the extension IDs in the guides. I added more context to make it clear that the IDs of custom builds will be different to the store version and screenshots.