### PR TITLE
Fix executable compilation on macOS

### DIFF
--- a/sites/cheerpx/src/content/docs/13-tutorials/simple-executable.mdx
+++ b/sites/cheerpx/src/content/docs/13-tutorials/simple-executable.mdx
@@ -50,12 +50,13 @@ gcc -static -m32 -o hello_cheerpx hello_cheerpx.c
 If you cannot compile directly on your system, use Docker to create a 32-bit statically linked executable. Open your terminal, navigate to your project directory, and run the following command:
 
 ```sh
-docker run --rm -v "$(pwd)":/src -w /src i386/debian bash -c "apt-get update && apt-get install -y gcc && gcc -static -m32 -o hello_cheerpx hello_cheerpx.c"
+docker run --rm --platform=linux/amd64 -v "$(pwd)":/src -w /src i386/debian bash -c "apt-get update && apt-get install -y gcc && gcc -static -m32 -o hello_cheerpx hello_cheerpx.c"
 ```
 
 Explanation:
 
 - `docker run --rm`: Runs a Docker container and removes it after execution.
+- `--platform=linux/amd64`: Defines the platform to use inside the container.
 - `-v "$(pwd)":/src`: Mounts your current directory into /src inside the container.
 - `-w /src`: Sets the working directory inside the container to /src.
 - `i386/debian`: Uses a 32-bit Debian image as the base.


### PR DESCRIPTION
The `docker run` command is failing on macOS if the `i386/debian` image isn't already in cache, the following error is shown:

```
docker: no matching manifest for linux/arm64/v8 in the manifest list entries.
```

To fix this, we add a `--platform=linux/amd64` flag to the command, as recommended by the following SO answer: https://stackoverflow.com/a/79440230/1513045