### PR TITLE
Document that inputMethods are enabled by default in 4.0 and onwards

### DIFF
--- a/sites/cheerpj/src/content/docs/12-reference/00-cheerpjInit.md
+++ b/sites/cheerpj/src/content/docs/12-reference/00-cheerpjInit.md
@@ -182,6 +182,9 @@ When this option is set to `true` CheerpJ will be able to receive text input fro
 cheerpjInit({ enableInputMethods: true });
 ```
 
+> [!note] Important
+> This option is enabled by default in CheerpJ 4.0 and newer, to disable it set it to `false`.
+
 ### `overrideShortcuts`
 
 ```ts


### PR DESCRIPTION
This option is now enabled by default, please just set the PR as ready. I will merge it once we release 4.0 in 1-2 weeks.