### PR TITLE
fix: Dead links in CheerpX site

### DIFF
--- a/sites/cheerpx/src/content/docs/13-tutorials/full_os.md
+++ b/sites/cheerpx/src/content/docs/13-tutorials/full_os.md
@@ -180,8 +180,8 @@ await cx.run("/bin/bash", ["--login"], {
 
 Learn more about `cx.run` in the [CheerpX.Linux.run] reference.
 
-[Files and filesystem]: docs/guides/File-System-support
-[CheerpX.Linux.create]: docs/reference/CheerpX.Linux/create
-[setConsole]: docs/reference/CheerpX.Linux/setConsole
-[CheerpX.Linux.run]: docs/reference/CheerpX.Linux/run
+[Files and filesystem]: /docs/guides/File-System-support
+[CheerpX.Linux.create]: /docs/reference/CheerpX.Linux/create
+[setConsole]: /docs/reference/CheerpX.Linux/setConsole
+[CheerpX.Linux.run]: /docs/reference/CheerpX.Linux/run
 [custom-disk-images]: /docs/guides/custom-images


### PR DESCRIPTION
Some links in CheerpX website for the "Full OS" tutorial are broken. They use relative pathing resulting in a 404. The screennshots below show the issue in the live website. 
![image](https://github.com/user-attachments/assets/b496d26c-a156-4a98-a6a7-3e4864bfac27)
> Screenshot shows how hovering over "CheerpX.Linux.run" redirects to "https://cheerpx.io/docs/tutorials/docs/reference/CheerpX.Linux/run"

![image](https://github.com/user-attachments/assets/cca5b365-a26a-45a1-8139-a9bb4da1f0b5)
> Screenshot shows live link 404

My change is making the links at the bottom of the content absolute links so that they resolve to "/docs/reference/..." instead of "/docs/tutorials/docs/refrence/...."

![image](https://github.com/user-attachments/assets/a5af1153-46c5-453c-bdfb-470ac0e44e21)
> Screenshot shows fix when hovering "CheerpX.Linux.run" redirects to "http://localhost:4321/docs/reference/CheerpX.Linux/run"

![image](https://github.com/user-attachments/assets/b2b963d6-0963-4bbe-9ee0-b8961b37fed4)
> Screenshot shows loaded content of docs
 