### PR TITLE
added documentation for installing Cheerp on newer ubuntu releases

### DIFF
--- a/sites/cheerp/src/content/docs/10-getting-started/01-installation.md
+++ b/sites/cheerp/src/content/docs/10-getting-started/01-installation.md
@@ -8,19 +8,51 @@ The first step to using Cheerp is to install the Cheerp toolchain.
 > [!info] Command Line Notation
 > Throughout this documentation, we’ll show some commands used in the terminal. Lines that you should enter in a terminal all start with `$`. You don’t need to type the `$` character; it’s the command line prompt shown to indicate the start of each command. Lines that don’t start with `$` typically show the output of the previous command.
 
-### Installing Cheerp on Linux
+## Installing Cheerp on Linux
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/cheerp.svg)](https://repology.org/project/cheerp/versions)
 
 #### Ubuntu
 
-Use our [PPA](https://launchpad.net/~leaningtech-dev/+archive/ubuntu/cheerp-ppa):
+> [!info] Releases
+> we offer both stable and nightly builds,
+> but since our stable build is at this time a few years old, we recommend using nightly
+
+Use our nightly build [PPA](https://launchpad.net/~leaningtech-dev/+archive/ubuntu/cheerp-nightly-ppa)
+
+(or alternatively our stable build [PPA](<(https://launchpad.net/~leaningtech-dev/+archive/ubuntu/cheerp-ppa):>))
 
 ```sh
-$ sudo add-apt-repository ppa:leaningtech-dev/cheerp-ppa
+$ sudo add-apt-repository ppa:leaningtech-dev/cheerp-nightly-ppa
 $ sudo apt-get update
 $ sudo apt-get install cheerp-core
 ```
+
+> [!warning] being ahead of our supported LTS builds
+> if you encounter a "the repo does not have a Release file" error
+> your Ubuntu release is most likely newer than our latest build. In this case you will need to manually edit the .sources file following the steps below.
+
+1. open the .sources file for the PPA release, which is located at:
+
+```
+/etc/apt/sources.list.d/leaningtech-dev-ubuntu-cheerp-nightly-ppa-<codename>.sources
+```
+
+With `<codename>` being replaced by the codename of your release
+
+(You can find your current codename using `lsb_release -cs`)
+
+2. Check which releases we have a build for [here](https://ppa.launchpadcontent.net/leaningtech-dev/cheerp-nightly-ppa/ubuntu/dists/) and change the `Suites:` line to specify our latest LTS release instead of your codename.
+
+   (Even if our latest build is an LTS release behind there should be no issues, since cheerp uses minimal dependencies)
+
+3. ```sh
+   $ sudo apt-get update
+   $ sudo apt-get install cheerp-core
+   ```
+
+<br>
+<br>
 
 #### Arch
 
@@ -39,7 +71,7 @@ $ yay -S cheerp-git
 
 Users on other Linux distributions must [build Cheerp from source](/docs/building-from-source/linux).
 
-### Installing Cheerp on Windows
+## Installing Cheerp on Windows
 
 Download the latest graphical installer from [GitHub](https://github.com/leaningtech/cheerp-meta/releases) and follow the installation wizard. The default installation path is currently the only supported one.
 
@@ -47,7 +79,7 @@ You can also [build Cheerp from source](/docs/building-from-source/windows) if y
 
 If you are using WSL, follow the [instructions for Linux](#installing-cheerp-on-linux).
 
-### Installing Cheerp on macOS
+## Installing Cheerp on macOS
 
 <!-- TODO: brew -->
 
@@ -59,7 +91,7 @@ The binary is not signed so you may need to run the following to stop Gatekeeper
 $ sudo xattr -d com.apple.quarantine /Applications/cheerp/bin/*
 ```
 
-## Troubleshooting
+## Testing
 
 To check whether you have installed Cheerp correctly, you can run the following command:
 


### PR DESCRIPTION
Added documentation for manually editing the .sources file when the user Ubuntu release is newer than our latest build.

Also changed the default PPA link to be our nightly build per request and added a note about it, as well as still linking the stable releases in case it's preferred.

First documentation edit so feedback is more than welcome! Ideally the parenthesised parts should be de-emphasized. But didn't want to mess with global tailwind classes and the like untill getting more familiar with the codebase

Lastly increased installing on <OS> header size for clarity and renamed troubleshooting to testing for accuracy