### PR TITLE
fix mdx conf: we were overriding existing remark plugins

### DIFF
--- a/packages/astro-theme/index.ts
+++ b/packages/astro-theme/index.ts
@@ -58,9 +58,7 @@ export default function ThemeIntegration(
 							frames: {},
 						},
 					}),
-					mdx({
-						remarkPlugins: [remarkReplaceVars],
-					}),
+					mdx(),
 					sitemap(),
 					tailwind(),
 					robotsTxt(),


### PR DESCRIPTION
mdx inherits the remark config if you leave the defaults. And we already add our remarkReplaceVars plugins there.