### PR TITLE
BP doc improvements

### DIFF
--- a/content/blog/fantastic-tail-calls-and-how-to-implement-them.md
+++ b/content/blog/fantastic-tail-calls-and-how-to-implement-them.md
@@ -142,13 +142,13 @@ The previous convention implemented by JavaScriptCore would prepare the frame as
 
 ![](./images/1oPumHN1qARa23hPPQO1dog.png)
 
-**Figure 5.** *Stack at different stages of the* **_A_** *->* **_B_** *->* **_C_** *tail call chain.* **_C_\***’s number of arguments modified the stack size of\* **_A_\***. Even if the return count was preserved with\* **_C_\***’s signature,\* **_A_** *expects the return values at incorrect offsets when* **_C_** \*returns.\*
+**Figure 5.** *Stack at different stages of the* ***A*** *->* ***B*** *->* ***C*** *tail call chain.* ***C*\***’s number of arguments modified the stack size of\* ***A*\***. Even if the return count was preserved with\* ***C*\***’s signature,\* ***A*** *expects the return values at incorrect offsets when* ***C*** \*returns.\*
 
 This is due to the fact that offsets for stack values are computed statically when parsing code for a function. As a solution, we changed the convention to encode return values at the opposite side of the stack, closer to the caller’s frame pointer.
 
 ![](./images/1DcEHV1nJyX-wJZLGtVI1iA.png)
 
-**Figure 6.** *Same depiction as in Fig. 5, with offsets that allow* **_A_** *to properly collect return values.*
+**Figure 6.** *Same depiction as in Fig. 5, with offsets that allow* ***A*** *to properly collect return values.*
 
 When **A** restores the stack pointer as if it had called **B**, it is able to find the return values where expected.
 

--- a/sites/browserpod/src/content/docs/10-getting-started/index.md
+++ b/sites/browserpod/src/content/docs/10-getting-started/index.md
@@ -7,7 +7,10 @@ description: Getting started with BrowserPod
 
 **BrowserPod is a technology for running node.js environments entirely client-side.**
 
-Upon completing the steps below, you’ll be able to run a basic node.js script right within your web browser!
+Upon completing the steps below, you'll be able to run a basic node.js script right within your web browser!
+
+> [!note] Prerequisites
+> This quickstart assumes you already have a web page or project where you can add scripts. If you're starting from scratch or want a more complete example with server setup and hosting, see the [basic NPM project tutorial].
 
 ## 1. Register a free account
 
@@ -42,7 +45,7 @@ const pod = await BrowserPod.boot({ apiKey: "your-key" });
 
 In order to see the output of our program, we need to set up a terminal.
 
-First, add a `pre` HTML element somewhere in the page:
+First, add a [`<pre>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/pre) HTML element somewhere in the page. This element preserves whitespace and displays text in a monospace font, making it ideal for terminal output:
 
 ```html
 <pre id="console" style="height: 100%;"></pre>
@@ -134,29 +137,34 @@ console.log(fs.readFileSync(__filename, "utf8"));
 
 ## Enable cross-origin isolation
 
-BrowserPod requires [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer), which itself requires the site to be cross-origin isolated. To enable cross-origin isolation, serve over HTTPS and set the following headers:
+BrowserPod requires [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer). For security reasons, browsers only allow `SharedArrayBuffer` on pages that are [cross-origin isolated](https://developer.mozilla.org/en-US/docs/Web/API/Window/crossOriginIsolated).
+
+To enable cross-origin isolation, your server must set the following HTTP headers:
 
 ```
 Cross-Origin-Embedder-Policy: require-corp
 Cross-Origin-Opener-Policy: same-origin
 ```
 
-For detailed instructions on how to configure headers in Nginx, check our [Nginx configuration guide].
+_You can use HTTP when serving from `localhost`, but make sure to serve over HTTPS when deploying._
 
-During development, you don't need to use HTTPS if you're using `localhost` as the origin, the `COEP` and `COOP` headers are always required though. You'll need to make sure you serve over HTTPS when you deploy.
+For more detailed instructions on how to configure headers in Nginx, check our [Basic server setup guide].
 
 > [!warning] Cross-origin isolation may break existing site functionality
 > Cross-origin isolation is a security feature that might impact your site in unexpected ways. For example, if you're embedding third-party iframes or opening cross-origin popup windows, you may need to make changes to your site to make them work. Test carefully!
 
 # Next steps
 
-For a more complex example that includes an integrated file editor, NPM dependencies, and hot reloading,
-see our [Vite+SvelteKit demo].
+- **Step-by-step tutorial:** For a complete walkthrough including project setup, server configuration, and working with NPM dependencies, see the [basic NPM project tutorial].
+- **Live demo:** For an interactive example with a file editor, NPM dependencies, and hot reloading, try our [Vite+SvelteKit demo].
+- **API reference:** Learn about all available methods in the [API reference].
 
 ---
 
-[Nginx configuration guide]: /docs/guides/nginx
+[basic NPM project tutorial]: /docs/tutorials/expressjs
+[Basic server setup guide]: /docs/guides/nginx
 [Vite+SvelteKit demo]: https://vitedemo.browserpod.io
+[API reference]: /docs/reference
 
 ## Have Questions?
 

--- a/sites/browserpod/src/content/docs/12-tutorials/00-expressjs.md
+++ b/sites/browserpod/src/content/docs/12-tutorials/00-expressjs.md
@@ -1,6 +1,6 @@
 ---
 title: Set up a basic NPM-based project
-description: In this tutorial you will set up a simple NPM projext that serves an HTTP server using Express.js
+description: In this tutorial you will set up a simple NPM project that serves an HTTP server using Express.js
 ---
 
 ## Prerequisites
@@ -67,9 +67,9 @@ app.listen(port, () => {
 ## BrowserPod setup: `index.html`
 
 The index.html file is more complex, so we will describe it in multiple steps,
-and leave out irrelevant boilerplate. you can see it in full at the end.
+and leave out irrelevant boilerplate. You can see the full code at the end.
 
-### UI elements
+### 1: UI elements
 
 Our simple page has 3 main UI elements:
 
@@ -85,7 +85,7 @@ The `portal` iframe will contain an embedded view of our server.
 
 The `console` div will show the console output of our application.
 
-### Import and initialize BrowserPod
+### 2: Import and initialize BrowserPod
 
 ```js
 import { BrowserPod } from "https://rt.browserpod.io/%BP_LATEST%/browserpod.js";
@@ -97,13 +97,19 @@ This code imports BrowserPod and boots a Pod.
 
 You will need a valid API key with at least 10 tokens available for the boot to succeed.
 
-### Hook the pod to the UI
+### 3: Set up the terminal
 
 ```js
 // Create a terminal and hook it to the console div.
 const terminalDiv = document.getElementById("console");
 const terminal = await pod.createDefaultTerminal(terminalDiv);
+```
 
+This creates a Terminal that displays output in the `console` div.
+
+### 4: Set up the Portal callback
+
+```js
 // Hook the portal to the preview iframe on creation
 const portalIframe = document.getElementById("portal");
 const urlDiv = document.getElementById("url");
@@ -113,10 +119,14 @@ pod.onPortal(({ url, port }) => {
 });
 ```
 
-This code creates a Terminal to use for console output, and sets up a callback
-that populates the `url` div and `portal` iframe with the Portal data.
+**Portals** are BrowserPod's way of exposing HTTP servers running inside the Pod to the outside world. When your Node.js code starts listening on an HTTP socket (e.g., `app.listen(3000)`), BrowserPod creates a Portal — a unique subdomain of `browserportal.io` that allows anyone to connect to your server from the Internet.
 
-### Copy the project files into the Pod's filesystem
+The `onPortal` callback is triggered whenever a new Portal becomes available. In this example, we:
+
+1. Display the Portal URL in our page
+2. Load the Portal URL in an iframe to show a live preview
+
+### 5: Copy the project files into the Pod's filesystem
 
 ```js
 // Utility function to copy files from the HTTP server into the Pod's
@@ -136,10 +146,10 @@ await copy_file(pod, "project/package.json");
 
 This code copies the project files into the Pod's filesystem.
 
-In this case the files are served alongiside the index.html page, but you can
+In this case the files are served alongside the index.html page, but you can
 get them from other sources, or embed them directly as strings.
 
-### Install dependencies
+### 6: Install dependencies
 
 ```js
 // Install dependencies
@@ -154,10 +164,10 @@ We finally execute some code in the Pod.
 
 This runs `npm install` to fetch the project's dependencies from the internet.
 
-You might want to bundle the `node_modules` directory and the `package-lock.json`
-file directly alongside the project files instead.
+> [!tip] Pre-bundling dependencies for faster startup
+> Running `npm install` at runtime means dependencies are downloaded each time the page loads. For production use, you could pre-install dependencies locally and serve the `package-lock.json` and `node_modules` directory alongside your project files, and copy them into the Pod's filesystem. This would skip the install step entirely for faster startup.
 
-### Run the application
+### 7: Run the application
 
 ```js
 // Run the server


### PR DESCRIPTION
on quickstart
- added prerequisites note
- added pre element link
- Reworded COEPS header section
- more next steps links

in the tutorial

- numbered the steps
- split up terminal setup and portal callback steps
- added short portal explanation
- fixed typos
- reworded loading modules directly into the pod tip