### PR TITLE
Fixed BP docs search functionality

### DIFF
--- a/packages/astro-theme/components/search/Pagefind.svelte
+++ b/packages/astro-theme/components/search/Pagefind.svelte
@@ -5,16 +5,14 @@
 	export let productId: string | undefined;
 	export let placeholder: string;
 	export let locale: string;
+	export let baseUrl: string;
 
 	let pagefind: Pagefind;
 	let results: PagefindResult[] = [];
 	let noResultsForQuery = false;
 
 	onMount(async () => {
-		const url =
-			productId === "cheerpj3"
-				? new URL(window.origin + "/docs/pagefind/pagefind.js").href // Add /docs/ for CJ so search bar is able to link correctly
-				: new URL(window.origin + "/pagefind/pagefind.js").href; // Can't use import.meta.url because Vite prefixes the module with /@fs.
+		const url = new URL(window.origin + baseUrl + "pagefind/pagefind.js").href;
 		// @ts-ignore
 		const pf = await import(/* @vite-ignore */ url);
 		await pf.init();
@@ -35,7 +33,7 @@
 
 		const response = await pagefind.debouncedSearch(query, {
 			filters: { productId, language: locale },
-			baseUrl: import.meta.env.BASE_URL,
+			baseUrl,
 		});
 		if (response === null) {
 			// Debounce.

--- a/packages/astro-theme/components/search/Search.astro
+++ b/packages/astro-theme/components/search/Search.astro
@@ -8,6 +8,8 @@ import { t } from "../../lib/i18n";
 interface Props {
 	filterProductId?: Product | "blog"; // data-pagefind-filter productId
 }
+
+const baseUrl = import.meta.env.BASE_URL || "/";
 ---
 
 <site-search class="inline-block w-full h-10 max-w-full">
@@ -35,6 +37,7 @@ interface Props {
 			productId={Astro.props.filterProductId}
 			placeholder={t("Type to search...", Astro.currentLocale)}
 			locale={Astro.currentLocale}
+			{baseUrl}
 		>
 			<div
 				slot="no-results"

--- a/sites/browserpod/astro.config.mjs
+++ b/sites/browserpod/astro.config.mjs
@@ -6,7 +6,7 @@ import { resolve } from "node:path";
 // https://astro.build/config
 export default defineConfig({
 	site: "https://browserpod.io",
-	base: "/docs",
+	base: "/docs/",
 	integrations: [
 		icon(),
 		theme({

--- a/sites/cheerpj/astro.config.mjs
+++ b/sites/cheerpj/astro.config.mjs
@@ -6,7 +6,7 @@ import { resolve } from "node:path";
 // https://astro.build/config
 export default defineConfig({
 	site: "https://cheerpj.com",
-	base: "/docs",
+	base: "/docs/",
 	integrations: [
 		icon(),
 		theme({


### PR DESCRIPTION
made Pagefinder.svelt just use Base URL  (passed from search.astro) instead of hardcoded check used prior.