### PR TITLE
Updating cheerp x licensing

### DIFF
--- a/sites/cheerpx/src/content/docs/23-licensing.md
+++ b/sites/cheerpx/src/content/docs/23-licensing.md
@@ -2,25 +2,52 @@
 title: Licensing
 ---
 
-CheerpX is free to use for _personal projects_, _FOSS projects_, and for _technical evaluations_.
+CheerpX is distributed for _free_ with the **CheerpX Community License**, which makes it free to use for _personal projects_, _FOSS projects_, and for _technical evaluations_.
 
-- Individuals can use CheerpX for **free**. This includes:
-  - Most open-source projects
-  - Personal projects that generate income
+**Commercial Licenses** are available for any use that falls outside of the scope of the **Community License**, including any _business use_ (with exception of one-person companies), _redistribution_ and _OEM use_.
+
+## CheerpX Community License
+
+You can use CheerpX for free if you fall into any of the following categories:
+
+- Individuals, including one-person companies. For example:
+  - Any personal projects, whether they generate income or not
   - Public-facing applications (such as games, educational applications, etc.)
-- Academic and non-profit organisations: [please enquire for eligibility][contact]
-- For all other organisations (commercial, public sector, etc.):
-  - Free for technical evaluations / testing
-  - Requires a Commercial license
+  - Commercial applications developed by one-person companies
+- Free and Open-Source Software (FOSS) projects
+- [Technical evaluations](#technical-evaluations)
+
+The **CheerpX Community License** allows unlimited, unmetered use of CheerpX from the `cxrtnc.leaningtech.com` domain. For self-hosted options, see the [CheerpX Commercial License](#cheerpx-commercial-license).
+
+## CheerpX Commercial License
+
+The **CheerpX Commercial License** allows CheerpX to be used in any scenario that falls outside the scope of the [**Community License**](#cheerpx-community-license).
+
+Full details on the commercial licensing options for CheerpX are available [here](https://cheerpx.io/licensing/).
+
+CheerpX can be used for free for technical evaluations before purchasing a commercial license (see [Technical Evaluations](#technical-evaluations)).
+
+The **CheerpX Commercial License** allows its usage in a commercial setting in addition of:
+
+- Self-hosting of the CheerpX runtime
+- Redistribution and OEM uses
+- Priority Support and SLA
+
+Pricing options are available for _small businesses_, _enterprises_, _public sector_, _academic institutions_, and _non-profit organizations_.
 
 ## Examples
 
-- Example 1: You are using CheerpX for a personal open-source project. **Free license.**
-- Example 2: You are a company and you want to use CheerpX to build a free customer-facing application. **You require a license.**
-- Example 3: You are a company and you want to use CheerpX to build a web application for internal use. **You require a license.**
-- Example 4: You are a company and are evaluating CheerpX to be used for a future commercial project. **Free license.**
-- Example 5: You are a public sector, not-for-profit, or academic organisation. [Contact us][contact].
-- Example 6: You are an individual developer building a commercial project. **Free license**.
+| Use case                                                                                                                                        | Required license |                             Action point                              |
+| :---------------------------------------------------------------------------------------------------------------------------------------------- | :--------------: | :-------------------------------------------------------------------: |
+| _You are an individual using CheerpX for a personal project (including one generating revenue)_                                                 | _**Community**_  |                       Give appropriate credits                        |
+| _You are an individual developer building a commercial project_                                                                                 | _**Community**_  |                       Give appropriate credits                        |
+| _You are a team using CheerpX in a FOSS project_                                                                                                | _**Community**_  |                       Give appropriate credits                        |
+| _You are a company and are evaluating CheerpX to be used for a future commercial project (see [technical evaluations](#technical-evaluations))_ | _**Community**_  |            [Contact sales](https://cheerpx.io/licensing/)             |
+| _You are a public sector, non-profit, or academic organisation and want to use CheerpX for an internal or public-facing project_                | _**Commercial**_ | [Contact us for a special quote](https://leaningtech.com/contact-us/) |
+| _You are a company and you want to use CheerpX to build customer-facing application (paid or free)._                                            | _**Commercial**_ |            [Contact sales](https://cheerpx.io/licensing/)             |
+| _You are a company and you want to use CheerpX on an internal application_                                                                      | _**Commercial**_ |            [Contact sales](https://cheerpx.io/licensing/)             |
+
+If you are not sure whether you require a license, or would like to discuss your options, please [contact us](https://leaningtech.com/contact-us/). Full licensing details are available [here](https://cheerpx.io/licensing/).
 
 ## Technical evaluations
 
@@ -37,17 +64,14 @@ If an application is not seen by internal or external users, it is considered a 
 
 ## Self-hosting
 
-If you wish to self-host CheerpX, you will need a license. [Contact us][contact] for more information.
+Self hosting CheerpX is often requested by enterprises for internal use of CheerpX. Self hosting involves hosting the CheerpX runtime within the company servers. If you wish to self-host CheerpX, you will need a [**Commercial License**](#cheerpx-commercial-license). Please [contact us](https://leaningtech.com/contact-us/) for more information.
 
-### System Integrators (SIs), Resellers and Distributors, OEMs
+## System Integrators (SIs), Resellers and Distributors, OEMs
 
-If you are a company who wants to offer CheerpJ integration as part of your software development services, you will need a special license and an agreement in place. Please [contact us directly](https://cheerpj.com/contact/) to discuss OEM or reseller licences.
+If you are a company who wants to offer CheerpX integration as part of your software development services, you will need a special license and an agreement in place. Please [contact us directly](https://leaningtech.com/contact-us/) to discuss OEM or reseller licences.
 
 For any doubt, please check the [Complete License].
 
 ---
 
-If you are not sure whether you require a license, [contact us][contact].
-
-[contact]: https://leaningtech.com/contact-us/?subject=CheerpX%20Enterprise%20Licence#mailus
 [Complete License]: https://github.com/leaningtech/cheerpx-meta/blob/main/LICENSE.txt


### PR DESCRIPTION
Mostly just stuck as close to CJ's licensing page as possible.

- did change runtime env to just runtime since runtime environment seems more of a java related term


I think for future improvement we _could_ mention our options for small businesses and NGO's/acedemic or public sector organisations more explicitely. But it is in the examples and opted for more consistency.

Lastly I rebased from the updating depend tree after no issues were found to (hopefully) prevent needing a seperate rebase from main before merging.