### PR TITLE
Fixed CJ docs build failing

### DIFF
--- a/translations/ja.json
+++ b/translations/ja.json
@@ -5,6 +5,7 @@
 	"Type to search...": "ドキュメントを検索する",
 	"Technology": "自社製品",
 	"Browser extensions": "ブラウザー拡張機能",
+	"Demos": "デモ",
 	"Resources": "リソース",
 	"Company": "企業",
 	"Documentation": "ドキュメント",


### PR DESCRIPTION
CJ/docs was failing because the new showcase branch didn't have a translation for the new demo link on the navbar. Should work now.

Translation is AI made so might want to check with a Native speaker