### PR TITLE
redirects for all sites

### DIFF
--- a/sites/browserpod/public/_redirects
+++ b/sites/browserpod/public/_redirects
@@ -1,6 +1,3 @@
-/docs/showcase   https://labs.leaningtech.com/showcase    301
-/docs/blog       https://labs.leaningtech.com/blog        301
-/docs/community   https://labs.leaningtech.com/showcase    301
 /docs/:page.html /docs/:page 301
 /docs/:category/:page.html /docs/:category/:page 301
 /docs/:cat1/:cat2/:page.html /docs/:cat1/:cat2/:page 301

--- a/sites/browserpod/public/_redirects
+++ b/sites/browserpod/public/_redirects
@@ -1,6 +1,6 @@
-/docs/:page.html /docs/:page 301
-/docs/:category/:page.html /docs/:category/:page 301
-/docs/:cat1/:cat2/:page.html /docs/:cat1/:cat2/:page 301
 /docs/showcase   https://labs.leaningtech.com/showcase    301
 /docs/blog       https://labs.leaningtech.com/blog        301
 /docs/community   https://labs.leaningtech.com/showcase    301
+/docs/:page.html /docs/:page 301
+/docs/:category/:page.html /docs/:category/:page 301
+/docs/:cat1/:cat2/:page.html /docs/:cat1/:cat2/:page 301

--- a/sites/cheerp/public/_redirects
+++ b/sites/cheerp/public/_redirects
@@ -1,0 +1,4 @@
+/showcase    https://labs.leaningtech.com/showcase    301
+/blog        https://labs.leaningtech.com/blog        301
+/docs/showcase   https://labs.leaningtech.com/showcase    301
+/docs/community   https://labs.leaningtech.com/showcase    301

--- a/sites/cheerp/src/content/docs/00-overview.mdx
+++ b/sites/cheerp/src/content/docs/00-overview.mdx
@@ -102,7 +102,7 @@ Know what you need? Jump straight to the relevant section:
 
 ## Community
 
-Cheerp is used effectively by a diverse range of development teams to enhance their web applications. For insights into how various organizations are using Cheerp, check out the case studies [here](https://leaningtech.com/case-studies/).
+Cheerp is used effectively by a diverse range of development teams to enhance their web applications. For insights into how various organizations are using Cheerp, check out the case studies [here](https://labs.leaningtech.com/showcase).
 
 We have a vibrant Discord community where you can ask questions, share your projects, and get community support.
 

--- a/sites/cheerpj/public/_redirects
+++ b/sites/cheerpj/public/_redirects
@@ -1,6 +1,3 @@
-/docs/:page.html /docs/:page 301
-/docs/:category/:page.html /docs/:category/:page 301
-/docs/:cat1/:cat2/:page.html /docs/:cat1/:cat2/:page 301
 /docs/showcase   https://labs.leaningtech.com/showcase    301
 /docs/blog       https://labs.leaningtech.com/blog        301
 /docs/community   https://labs.leaningtech.com/showcase    301

--- a/sites/cheerpj/src/content/docs/00-overview.mdx
+++ b/sites/cheerpj/src/content/docs/00-overview.mdx
@@ -149,11 +149,7 @@ You can also see CheerpJ in action in [JavaFiddle](https://javafiddle.leaningtec
 
 ## Community
 
-CheerpJ is used in production by teams at NASA, Siemens, UBS, and [many others](https://leaningtech.com/case-studies/).
-
-There are several community projects that use CheerpJ, such as:
-
-<ShowcaseList tag="CheerpJ" limit={2} />
+CheerpJ is used in production by teams at NASA, Siemens, UBS, and [many others](https://labs.leaningtech.com/showcase).
 
 <div class="flex justify-end pt-4">
 	<LinkButton

--- a/sites/cheerpx/public/_redirects
+++ b/sites/cheerpx/public/_redirects
@@ -1,0 +1,4 @@
+/showcase    https://labs.leaningtech.com/showcase    301
+/blog        https://labs.leaningtech.com/blog        301
+/docs/showcase  https://labs.leaningtech.com/showcase  301
+/docs/community   https://labs.leaningtech.com/showcase    301


### PR DESCRIPTION
since ghe blog and showcase now only lives within labs, some redirects are necessary. 

Please note that redirects on browserpod site didn't work and I didn't include them here, these need to be handled from the main site (opened a PR already with suggested solution)