### PR TITLE
further blog banner image resolution increase

### DIFF
--- a/packages/astro-theme/components/BlogPostCard.astro
+++ b/packages/astro-theme/components/BlogPostCard.astro
@@ -43,7 +43,7 @@ const blog_url =
 			<Image
 				src={post.data.heroImage}
 				width={size === "wide" ? 1800 : 1170}
-				height={768}
+				height={size === "wide" ? 947 : 615}
 				format="webp"
 				alt=""
 				class="rounded-xl mb-4 bg-bg-100 object-cover w-full h-64 self-center"

--- a/packages/astro-theme/layouts/BlogPost.astro
+++ b/packages/astro-theme/layouts/BlogPost.astro
@@ -65,8 +65,8 @@ const site = getSite(Astro.site?.hostname);
 					src={heroImage}
 					alt=""
 					class="rounded-xl w-full mx-auto mb-8 object-cover max-h-[30rem] bg-white"
-					width={1232}
-					height={480}
+					widths={[768, 1232, 2464]}
+					sizes="(max-width: 1280px) 100vw, 1232px"
 					quality="max"
 				/>
 			)


### PR DESCRIPTION
increased resolution and added logic to height.

Resolution had been increased previously but still needed further increasing to avoid bluriness.

Besides this, the height resolution did not have the same check the width had to check for the aspect ratio, causing a mismatched aspect ratio that astro would then process to make it still fit, resulting in more bluriness. 