### PR TITLE
Cj docs remove await cheerpOSAddStringFile()

### DIFF
--- a/sites/cheerpj/src/content/docs/11-guides/filesystem.mdx
+++ b/sites/cheerpj/src/content/docs/11-guides/filesystem.mdx
@@ -62,7 +62,7 @@ async function addStringFileToCheerpJ() {
 	const content = "Default content.";
 
 	try {
-		await cheerpOSAddStringFile(`/str/${fileName}`, content);
+		cheerpOSAddStringFile(`/str/${fileName}`, content);
 		console.log(`File "${fileName}" added to /str/.`);
 	} catch (e) {
 		console.error("Error writing file to /str/:", e);

--- a/sites/cheerpj/src/content/docs/11-guides/filesystem.mdx
+++ b/sites/cheerpj/src/content/docs/11-guides/filesystem.mdx
@@ -57,16 +57,11 @@ The quickest way to place a file into CheerpJ's virtual filesystem from JavaScri
 
 ```js
 // Call this only after cheerpjInit() has resolved.
-async function addStringFileToCheerpJ() {
+function addStringFileToCheerpJ() {
 	const fileName = "default.txt";
 	const content = "Default content.";
-
-	try {
-		cheerpOSAddStringFile(`/str/${fileName}`, content);
-		console.log(`File "${fileName}" added to /str/.`);
-	} catch (e) {
-		console.error("Error writing file to /str/:", e);
-	}
+	cheerpOSAddStringFile(`/str/${fileName}`, content);
+	console.log(`File "${fileName}" added to /str/.`);
 }
 ```
 


### PR DESCRIPTION
- removed unnecessary await call for the sync cheerpOSAddStringFile() function
- checked rest of docs for other spurious awaits in front of sync funcs
- remove async + try catch block from code snippet in question since it's unnecessary and clutters the code snippet (ref: filesystem method 2) 