### PR TITLE
Feat: Added Google Tag Manager to CheerpJ docs.

### DIFF
--- a/packages/astro-theme/components/BaseHead.astro
+++ b/packages/astro-theme/components/BaseHead.astro
@@ -2,6 +2,7 @@
 import { SITE_TITLE } from "../consts";
 import companyFavicon from "../assets/branding/company/tower.svg";
 import { productFromUrl } from "../lib/products";
+import { gtmContainerId } from "../lib/gtm";
 import { getLocalisedPaths } from "../lib/i18n";
 
 export interface Props {
@@ -75,11 +76,16 @@ if (isBlogPost && !plausibleDomains.includes("labs.leaningtech.com"))
 
 const localised = getLocalisedPaths(Astro.url.pathname, Astro.currentLocale);
 
+const gtmId = gtmContainerId(product);
 const gtmScript =
-	"(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-M4T2J9TS');";
+	gtmId &&
+	`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${gtmId}');`;
 ---
 
 <meta charset="utf-8" />
+
+<!-- Google Tag Manager -->
+{gtmScript && <script is:inline set:html={gtmScript} />}
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -131,9 +137,6 @@ const gtmScript =
 		<link rel="alternate" hreflang={lang} href={url} />
 	))
 }
-
-<!-- Google Tag Manager -->
-{product?.id === "browserpod" && <script is:inline set:html={gtmScript} />}
 
 <!-- Plausible analytics -->
 <script

--- a/packages/astro-theme/components/BaseHead.astro
+++ b/packages/astro-theme/components/BaseHead.astro
@@ -2,13 +2,13 @@
 import { SITE_TITLE } from "../consts";
 import companyFavicon from "../assets/branding/company/tower.svg";
 import { productFromUrl } from "../lib/products";
-import { gtmContainerId } from "../lib/gtm";
 import { getLocalisedPaths } from "../lib/i18n";
 
 export interface Props {
 	title: string;
 	description: string;
 	image?: string | undefined;
+	gtmId?: string | undefined;
 }
 
 const isBlogPost =
@@ -45,6 +45,7 @@ const {
 	title,
 	description,
 	image = product?.ogImage ?? "/social/common@2x.png",
+	gtmId,
 } = Astro.props;
 
 // Sniff mime type from favicon extension
@@ -76,7 +77,6 @@ if (isBlogPost && !plausibleDomains.includes("labs.leaningtech.com"))
 
 const localised = getLocalisedPaths(Astro.url.pathname, Astro.currentLocale);
 
-const gtmId = gtmContainerId(product);
 const gtmScript =
 	gtmId &&
 	`(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','${gtmId}');`;

--- a/packages/astro-theme/layouts/Shell.astro
+++ b/packages/astro-theme/layouts/Shell.astro
@@ -1,6 +1,8 @@
 ---
 import BaseHead from "../components/BaseHead.astro";
 import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
+import { productFromUrl } from "../lib/products";
+import { gtmContainerId } from "../lib/gtm";
 
 interface Props {
 	title?: string;
@@ -11,6 +13,8 @@ interface Props {
 }
 
 const { title, description, image, site, filterPage = false } = Astro.props;
+
+const gtmId = gtmContainerId(productFromUrl(Astro.url));
 ---
 
 <!doctype html>
@@ -135,6 +139,20 @@ const { title, description, image, site, filterPage = false } = Astro.props;
 	<body
 		class="font-sans antialiased min-w-full min-h-screen flex flex-col m-0 p-0 bg-bg-900 text-bg-200"
 	>
+		<!-- Google Tag Manager (noscript) -->
+		{
+			gtmId && (
+				<noscript>
+					<iframe
+						src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+						height="0"
+						width="0"
+						style="display:none;visibility:hidden"
+						title="Google Tag Manager"
+					/>
+				</noscript>
+			)
+		}
 		<slot />
 	</body>
 </html>

--- a/packages/astro-theme/layouts/Shell.astro
+++ b/packages/astro-theme/layouts/Shell.astro
@@ -24,6 +24,7 @@ const gtmId = gtmContainerId(productFromUrl(Astro.url));
 			title={title || SITE_TITLE}
 			description={description || SITE_DESCRIPTION}
 			{image}
+			{gtmId}
 		/>
 		<style is:inline is:global>
 			@font-face {

--- a/packages/astro-theme/lib/gtm.ts
+++ b/packages/astro-theme/lib/gtm.ts
@@ -1,0 +1,13 @@
+import type { ProductData } from "./products";
+
+// GTM container per product. Products without an entry don't load GTM.
+const containers: Partial<Record<ProductData["id"], string>> = {
+	browserpod: "GTM-M4T2J9TS",
+	cheerpj3: "GTM-WXJ325GT",
+};
+
+export function gtmContainerId(
+	product: ProductData | undefined
+): string | undefined {
+	return product && containers[product.id];
+}


### PR DESCRIPTION
This pull requests adds the Google Tag Manager tag to the CheerpJ Docs site, so that it will correctly feed analytics data into the CheerpJ GA4 property. 

I've included Claude's comment below so you've got sight of its summary: 

> Google Tag Manager (container GTM-WXJ325GT) is now installed on the CheerpJ docs site, and I verified it in a real build.
> 
> One note on placement: [src/content/docs]only holds markdown content — there's no <head> or <body> there. Those come from the shared theme package that all Leaning Tech sites use, which already had a GTM setup for browserpod. So I generalized that existing pattern rather than hardcoding a second copy:
> 
> - **New [gtm.ts]** a small per-product map of GTM container IDs: browserpod keeps its existing GTM-M4T2J9TS, and cheerpj3 (which is what every page of cheerpj.com resolves to, including all of /docs) gets your new GTM-WXJ325GT. Other sites (labs, cheerp.io, cheerpx.io) load no GT
> - **[BaseHead.astro:84-85]**The GTM script now uses the mapped container ID, and I moved it up so it renders immediately after <meta charset>, i.e. as high in <head> as possible per Google's instructions (it was previously near the bottom of the head).
> - **[Shell.astro:154-167]** — added the <noscript> iframe fallback immediately after the opening <body> tag. This part was missing entirely from the earlier browserpod install, so browserpod gains it too.
> Verification: I built the cheerpj site — all 80 real pages contain the script as the first element in <head> and the noscript right after <body>; the 128 files without it are all http-equiv="refresh" redirect stubs, which is expected. I also rebuilt the browserpod site to confirm the shared-theme change didn't disturb it: its 47 pages still carry GTM-M4T2J9TS and none picked up the CheerpJ container.
> 
> One thing to double-check on your side: the tag fires on all of cheerpj.com, not just /docs — that's how the site is built (the whole domain is one Astro site with base /docs/, plus the theme's shared pages). If you wanted it strictly limited to certain paths, that's better handled with a trigger condition inside the GTM container itself.