### PR TITLE
cx docs dataDevice writeFile corrections

### DIFF
--- a/sites/cheerpx/public/_redirects
+++ b/sites/cheerpx/public/_redirects
@@ -2,3 +2,5 @@
 /blog        https://labs.leaningtech.com/blog        301
 /docs/showcase  https://labs.leaningtech.com/showcase  301
 /docs/community   https://labs.leaningtech.com/showcase    301
+
+/docs/reference/CheerpX.DataDevice/writeFIle    /docs/reference/CheerpX.DataDevice/writeFile    301

--- a/sites/cheerpx/src/content/docs/11-guides/File-System-support.md
+++ b/sites/cheerpx/src/content/docs/11-guides/File-System-support.md
@@ -177,7 +177,7 @@ const cx = await CheerpX.Linux.create({
 
 ### Adding files
 
-You can add files to a [`DataDevice`](/docs/reference/CheerpX.DataDevice) from JavaScript using the [`writeFile`](/docs/reference/CheerpX.DataDevice/writeFIle) method:
+You can add files to a [`DataDevice`](/docs/reference/CheerpX.DataDevice) from JavaScript using the [`writeFile`](/docs/reference/CheerpX.DataDevice/writeFile) method:
 
 ```javascript
 await dataDevice.writeFile("/filename", "File content here");

--- a/sites/cheerpx/src/content/docs/13-reference/01-CheerpX.DataDevice/writeFIle.md
+++ b/sites/cheerpx/src/content/docs/13-reference/01-CheerpX.DataDevice/writeFIle.md
@@ -6,7 +6,10 @@ description: Write data to a new file in the CheerpX DataDevice.
 ```ts
 namespace CheerpX {
 	class DataDevice {
-		async writeFile(filename: string, contents: string): Promise<void>;
+		async writeFile(
+			filename: string,
+			contents: string | Uint8Array
+		): Promise<void>;
 	}
 }
 ```
@@ -14,7 +17,7 @@ namespace CheerpX {
 ## Parameters
 
 - **filename (`string`)** - The path to the file within the device, starting with a `/` (e.g., `/filename`). The path should not include the mount point.
-- **contents (`string`)** - The data to write to the file.
+- **contents (`string | Uint8Array`)** - The data to write to the file. Can be either a string or a `Uint8Array`.
 
 ## Returns
 

--- a/sites/cheerpx/src/content/docs/13-reference/01-CheerpX.DataDevice/writeFIle.md
+++ b/sites/cheerpx/src/content/docs/13-reference/01-CheerpX.DataDevice/writeFIle.md
@@ -6,10 +6,7 @@ description: Write data to a new file in the CheerpX DataDevice.
 ```ts
 namespace CheerpX {
 	class DataDevice {
-		async writeFile(
-			filename: string,
-			contents: string | Uint8Array
-		): Promise<void>;
+		async writeFile(filename: string, contents: string): Promise<void>;
 	}
 }
 ```
@@ -17,7 +14,7 @@ namespace CheerpX {
 ## Parameters
 
 - **filename (`string`)** - The path to the file within the device, starting with a `/` (e.g., `/filename`). The path should not include the mount point.
-- **contents (`string | Uint8Array`)** - The data to write to the file. Can be either a string or a `Uint8Array`.
+- **contents (`string`)** - The data to write to the file.
 
 ## Returns
 


### PR DESCRIPTION
Removed reference to Uint8Array in DataDevice writeFile doc since I can only find this function being passed a String.
Also fixed typo in writeFile file name and added this to redirects (specifically to not bother the user who flagged the issue in the first place / other users using that link on discord)