### PR TITLE
Fix: Shortened Rust blog title for This Week In Rust.

### DIFF
--- a/sites/labs/src/content/blog/browserpod-rust.mdx
+++ b/sites/labs/src/content/blog/browserpod-rust.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Beyond WASI: Running any Rust application in the browser with BrowserPod 3.0"
+title: "Beyond WASI: Running Rust applications in the browser"
 description: |
   BrowserPod can now run real Rust programs in the browser, compiled from unmodified source with stock rustc and cargo.
 authors:

--- a/sites/labs/src/content/blog/browserpod-rust.mdx
+++ b/sites/labs/src/content/blog/browserpod-rust.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Beyond WASI: Running Rust applications in the browser"
+title: "Beyond WASI: Rust in-browser"
 description: |
   BrowserPod can now run real Rust programs in the browser, compiled from unmodified source with stock rustc and cargo.
 authors:

--- a/sites/labs/src/content/blog/browserpod-rust.mdx
+++ b/sites/labs/src/content/blog/browserpod-rust.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Beyond WASI: Rust in-browser"
+title: "Beyond WASI: Running full Rust applications in-browser"
 description: |
-  BrowserPod can now run real Rust programs in the browser, compiled from unmodified source with stock rustc and cargo.
+   Run real Rust programs in-browser.
 authors:
   - yuri
 pubDate: "August 13 2026"


### PR DESCRIPTION
This Week In Rust requires shorter titles of five words or less. We can change it back at some point, but just to get it published there I've shortened it significantly for now as it will give us a large distribution opportunity.