### PR TITLE
Revert "Fix: Shortened Rust blog title for This Week In Rust. (#460)"

### DIFF
--- a/sites/labs/src/content/blog/browserpod-rust.mdx
+++ b/sites/labs/src/content/blog/browserpod-rust.mdx
@@ -1,7 +1,7 @@
 ---
-title: "Beyond WASI: Running full Rust applications in-browser"
+title: "Beyond WASI: Running any Rust application in the browser with BrowserPod 3.0"
 description: |
-   Run real Rust programs in-browser.
+  BrowserPod can now run real Rust programs in the browser, compiled from unmodified source with stock rustc and cargo.
 authors:
   - yuri
 pubDate: "August 13 2026"


### PR DESCRIPTION
This reverts commit 1be575f7654a48220e70fdb2adfee39d05b1c1ce.