### PR TITLE
Fix docs canonical URLs and add missing redirects

### DIFF
--- a/packages/astro-theme/components/BaseHead.astro
+++ b/packages/astro-theme/components/BaseHead.astro
@@ -36,7 +36,7 @@ const browserpodCanonicals: Record<string, string> = {
 const normalisedPath = Astro.url.pathname.replace(/(?:\.html|\/)$/, "");
 const canonicalURL = browserpodCanonicals[normalisedPath]
 	? new URL(browserpodCanonicals[normalisedPath])
-	: new URL(Astro.url.pathname, canonicalSite);
+	: new URL(normalisedPath || "/", canonicalSite);
 
 const product = productFromUrl(canonicalURL);
 const favicon = product?.favicon ?? companyFavicon.src;
@@ -118,7 +118,7 @@ const gtmScript =
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />
-<meta property="og:url" content={Astro.url} />
+<meta property="og:url" content={canonicalURL} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
 <meta property="og:image" content={new URL(image, Astro.url)} />
@@ -126,7 +126,7 @@ const gtmScript =
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:url" content={Astro.url} />
+<meta property="twitter:url" content={canonicalURL} />
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />

--- a/sites/browserpod/public/_redirects
+++ b/sites/browserpod/public/_redirects
@@ -1,3 +1,3 @@
-/docs/:page.html /docs/:page 301
-/docs/:category/:page.html /docs/:category/:page 301
-/docs/:cat1/:cat2/:page.html /docs/:cat1/:cat2/:page 301
+/docs/:page.html                /docs/:page                      301
+/docs/:category/:page.html      /docs/:category/:page            301
+/docs/:cat1/:cat2/:page.html    /docs/:cat1/:cat2/:page          301

--- a/sites/browserpod/src/pages/sitemap.xml.ts
+++ b/sites/browserpod/src/pages/sitemap.xml.ts
@@ -19,21 +19,13 @@ export const GET: APIRoute = async () => {
 		return true;
 	});
 
-	// The /docs/ landing page is served by the theme's pages/docs/index.astro,
-	// not the content collection, so it isn't in `entries`. Add it explicitly.
-	const landingUrl = `${BASE}/docs/`;
-
+	// The /docs/ landing page is served by the theme's pages/docs/index.astro, and it's only an html redirect, so it's not in the nav.
 	// entry.href is already "/docs/<slug>". Normalise and drop duplicates.
 	const innerUrls = Array.from(
 		new Set(entries.map((entry) => `${BASE}${entry.href}`))
 	).sort();
 
-	const pages = [
-		{ loc: landingUrl, priority: "0.8" },
-		...innerUrls
-			.filter((u) => u !== landingUrl)
-			.map((loc) => ({ loc, priority: "0.7" })),
-	];
+	const pages = innerUrls.map((loc) => ({ loc, priority: "0.7" }));
 
 	const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">


### PR DESCRIPTION
# Google search console report

This PR was prompted by google search engine reported 112 pages not being indexed. Luckily, upon further inspection this seemed a lot worse than it is. Only 7 pages are real content Google declined to index. Given this and the monorepo merge being imminent, I'm now switching back to the CI cleanup. Since a lot of these issues will be easier to fix with it being in one repo. That said, I do still have a couple small fixes that should take out some entries and give small qol improvements.



## The canonical URL bug

`packages/astro-theme/index.ts` sets `build: { format: "file" }`, so Astro emits `overview.html` and `Astro.url.pathname` carries the suffix throughout the build. Which in itself is not an issue since CF serves the URL extentionless and redirects the .html version to it.

But we built the canonical and og:url from the Astro pathname, resulting in every doc page declaring a canonical that points to a URL that points back to itself 😅.

This is the only place where we have links with .html on it (internal links and sitemap are all extensionless). This caused 24 "page with redirect" entries.

- The twitter url also used the .html version so I've changed that as well. :ok_hand: 

### Fix
Made canonical fallback and og:url take the `normalisedpath` which is extensionless. Note that this is a theme change that affects all doc sites.

## Sitemap
The sitemap had /docs hard coded on high priority. But /docs doesn't serve the homepage, only a meta refresh tag. **This is what causes the split second blank page.** Since this redirect happens at html level google won't index it. So it doesn't make sense to submit it as our highest priority URL. I've removed the entry, and will add a redirect after the monorepo merge.

# Post monorepo merge work

## _redirects
There were also 8 doc paths that have been changed since being indexed, added them to the `_redirects` file at first, but due to the dual deployment setup and differing roots and deployment rules between testing and production I'm saving this for after the merge.

I've documented them as well but for visibility's sake the redirects will be:
/docs/tutorials/expressjs   →  /docs/getting-started/expressjs
/docs/tutorials             →  /docs/getting-started
/docs/licensing             →  /docs/more/licensing
/docs/guides/nginx          →  /docs/guides/hosting
/docs/guides/natives        →  /docs/guides/working-around-native-npm-dependencies
/docs/demos/PackagePod      →  /showcase/package-pod/
/docs/demos/SaySomething    →  /showcase/say-something/
/docs/demos                 →  /showcase/
/docs/showcase              →  /showcase/
/docs/community             →  /showcase/
/docs/blog                  →  https://labs.leaningtech.com/blog
/docs  and  /docs/          →  /docs/overview          # replaces the meta-refresh stub


### Why add redirect rather than fixing our source?
Because there's no link to edit. The deprecated paths are the result of file renaming and moving. And the reference to the old URL's aren't in our repo but in googles index (plus potentially user bookmarks etc.).