### PR TITLE
cj doc networking headscale update

### DIFF
--- a/sites/cheerpj/src/content/docs/11-guides/Networking.md
+++ b/sites/cheerpj/src/content/docs/11-guides/Networking.md
@@ -87,4 +87,4 @@ To learn more about CheerpJ's Tailscale APIs please visit [the reference](/docs/
 
 ### Self-hosting Headscale
 
-Headscale is an open-source and self-hosted implementation of the Tailscale control server. To work with Headscale and CheerpJ we suggest using [this fork](https://github.com/leaningtech/headscale).
+Headscale is an open-source and self-hosted implementation of the Tailscale control server. To self-host Headscale for use with CheerpJ, follow the [official Headscale setup guide](https://headscale.net/stable/setup/requirements/).


### PR DESCRIPTION
Removed stale fork link, replaced with the official Headscale setup guide link.

Considered adding information about version compatibility (requiring newer Tailscale client than what's currently shipped in CheerpJ). I haven't seen the update in the changelog or latest release yet.
I can add this once the latest has been released.